### PR TITLE
Fix the deployment of the website

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -73,10 +73,8 @@ jobs:
 
       - name: Deploy website
         if: ${{ github.event_name == 'push' || steps.commit_push.outputs.publish == 'true' }}
-        uses: ItsKarma/aws-cli@v1.70.0
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "eu-central-1"
-        with:
-          args: s3 sync ./source/build s3://symfony-translations.nyholm.tech --cache-control max-age=7200
+        run: aws s3 sync ./source/build s3://symfony-translations.nyholm.tech --cache-control max-age=7200


### PR DESCRIPTION
The unofficial aws-cli action used previously is broken because it uses an old version of aws-cli without pinning the Python version to ensure compatibility.
Given that the AWS CLI is already preinstalled in the GitHub Actions runner, this now uses it directly.