### PR TITLE
Avoid making the sync workflow fail when there is no change

### DIFF
--- a/.github/workflows/sync-sf-translations.yml
+++ b/.github/workflows/sync-sf-translations.yml
@@ -49,7 +49,7 @@ jobs:
           if [[ $(git diff --numstat | wc -l) -eq 0 ]]; then
             echo "No significant changes."
             echo "make_pr=false" >> $GITHUB_OUTPUT
-            exit 1
+            exit 0
           fi
           
           echo "make_pr=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This makes the maintenance easier as a failed workflow will actually mean that something is broken in it.
Not having to synchronize any change is something that will happen very often.