### PR TITLE
Escape pipes in markdown tables

### DIFF
--- a/src/Command/OpenIssuesCommand.php
+++ b/src/Command/OpenIssuesCommand.php
@@ -67,7 +67,7 @@ final class OpenIssuesCommand extends Command
                 $details .= '| Id | English | Translation | Status |'.\PHP_EOL;
                 $details .= '| -- | -- | -- | -- |'.\PHP_EOL;
                 foreach ($missingTranslation->getMissingTranslations() as $missing) {
-                    $details .= sprintf('| %d | %s | %s | %s |', $missing['id'], $missing['source'], $missing['trans'], 'needs-review-translation' === $missing['state'] ? 'Needs review' : 'Missing').\PHP_EOL;
+                    $details .= sprintf('| %d | %s | %s | %s |', $missing['id'], str_replace('|', '\|', $missing['source']), $missing['trans'] === null ? '' : str_replace('|', '\|', $missing['trans']), 'needs-review-translation' === $missing['state'] ? 'Needs review' : 'Missing').\PHP_EOL;
                 }
                 $details .= \PHP_EOL;
             }


### PR DESCRIPTION
The `|` character needs to be escaped to avoid being treated as a cell delimiter in the markdown table when dealing with pluralized messages.